### PR TITLE
Update clevo_acpi.c for Linux 6.10

### DIFF
--- a/src/clevo_acpi.c
+++ b/src/clevo_acpi.c
@@ -186,7 +186,9 @@ static const struct acpi_device_id clevo_acpi_device_ids[] = {
 static struct acpi_driver clevo_acpi_driver = {
 	.name = DRIVER_NAME,
 	.class = DRIVER_NAME,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
 	.owner = THIS_MODULE,
+#endif
 	.ids = clevo_acpi_device_ids,
 	.flags = ACPI_DRIVER_ALL_NOTIFY_EVENTS,
 	.ops = {


### PR DESCRIPTION
The upstream kernel removed the owner field of `struct acpi_driver` in version 6.10 (https://github.com/torvalds/linux/commit/cc85f9c05bba23eb525497b42ac5b74801ccbd87). Fix the resulting compile error by removing the now-obsolete assignment to `.owner` in kernel 6.10 and later.